### PR TITLE
travis: retain documentation building only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,60 +20,16 @@
 notifications:
   email: false
 
-services:
-  - mysql
-  - redis
-  - elasticsearch
-
 sudo: false
 
 language: python
 
-cache:
-  - apt
-  - pip
-
-env:
-  - REQUIREMENTS=lowest REXTRAS=docs
-  - REQUIREMENTS=release REXTRAS=docs
-  - REQUIREMENTS=devel REXTRAS=docs
-
 python:
-# FIXME: the build times out on Python 2.6 (inveniosoftware/invenio#1789)
-#  - "2.6"
   - "2.7"
 
-addons:
-  apt:
-    packages:
-      - apache2
-      - git
-      - liblzma-dev
-      - nodejs
-      - poppler-utils
-
-before_install:
-  - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock"
-  - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
-  - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
-  - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
-
 install:
-  - "travis_retry pip install unittest2"
-  - "travis_retry pip install -r .travis-$REQUIREMENTS-requirements.txt --allow-all-external"
-  - "travis_retry pip install -e .[$REXTRAS] --process-dependency-links"
-  - "npm update"
-  - "npm install --silent -g bower less clean-css uglify-js requirejs"
-  # All the step below this points are solely for test purposes, don't use them
-  # to setup your invenio installation. Please do RTFM instead (INSTALL.rst).
-  - "./scripts/setup_devmode.sh"
-
-before_script:
-  - "inveniomanage apache create-config"
-  - "inveniomanage database init --yes-i-know || echo ':('"
-  - "inveniomanage database create --quiet || echo ':('"
+  - travis_retry pip install sphinx
 
 script:
-  - "sphinx-build -qnNW docs docs/_build/html"
-  - "python setup.py test"
+  - sphinx-build -qnNW docs docs/_build/html
+  - python setup.py build_sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,10 +50,10 @@ except ImportError:
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
-sys.path.append(os.path.abspath('_ext'))
+#sys.path.append(os.path.abspath('_ext'))
 #sys.path.append(os.path.abspath('_themes'))
 #sys.path.append(os.path.abspath('.'))
-sys.path.append(os.path.abspath('../invenio'))
+#sys.path.append(os.path.abspath('../invenio'))
 
 
 def setup(app):
@@ -68,10 +68,7 @@ def setup(app):
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['flask_app',
-              'sphinx.ext.autodoc',
-              'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx']
+extensions = ['sphinx.ext.intersphinx']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/deprecationpolicy.rst
+++ b/docs/deprecationpolicy.rst
@@ -20,6 +20,3 @@
 ==================
 Deprecation policy
 ==================
-
-.. automodule:: invenio.utils.deprecation
-   :members:


### PR DESCRIPTION
- Amends Travis CI configuration in order to build documentation only,
  following up the separation of `invenio-base` and related packages.
- Amends documentation in a minimal manner to ensure the build passes.
  The content of the documentation will be enriched subsequently.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
